### PR TITLE
Replace bash with sh in resource listing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-terraform:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for terraform from resource list..."; \
 		cd $(MMROOT) && \
-		sh $(ROOT)/list_resources.sh $(SPECROOT) | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
+		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
 	else \
 		echo "==> Generating source code for terraform from given name..."; \
 		cd $(MMROOT) && \
@@ -71,7 +71,7 @@ build-ansible:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for ansible from resource list..."; \
 		cd $(MMROOT) && \
-		sh $(ROOT)/list_resources.sh $(SPECROOT) | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
+		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
 	else \
 		echo "==> Generating source code for ansible from given name..."; \
 		cd $(MMROOT) && \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-terraform:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for terraform from resource list..."; \
 		cd $(MMROOT) && \
-		@bash $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
+		@sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
 	else \
 		echo "==> Generating source code for terraform from given name..."; \
 		cd $(MMROOT) && \
@@ -71,7 +71,7 @@ build-ansible:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for ansible from resource list..."; \
 		cd $(MMROOT) && \
-		@bash $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
+		@sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
 	else \
 		echo "==> Generating source code for ansible from given name..."; \
 		cd $(MMROOT) && \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-terraform:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for terraform from resource list..."; \
 		cd $(MMROOT) && \
-		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
+		sh $(ROOT)/list_resources.sh $(SPECROOT) | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
 	else \
 		echo "==> Generating source code for terraform from given name..."; \
 		cd $(MMROOT) && \
@@ -71,7 +71,7 @@ build-ansible:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for ansible from resource list..."; \
 		cd $(MMROOT) && \
-		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
+		sh $(ROOT)/list_resources.sh $(SPECROOT) | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
 	else \
 		echo "==> Generating source code for ansible from given name..."; \
 		cd $(MMROOT) && \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-terraform:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for terraform from resource list..."; \
 		cd $(MMROOT) && \
-		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
+		sh $(ROOT)/list_resources.sh $(MMROOT) | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
 	else \
 		echo "==> Generating source code for terraform from given name..."; \
 		cd $(MMROOT) && \
@@ -71,7 +71,7 @@ build-ansible:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for ansible from resource list..."; \
 		cd $(MMROOT) && \
-		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
+		sh $(ROOT)/list_resources.sh $(MMROOT) | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
 	else \
 		echo "==> Generating source code for ansible from given name..."; \
 		cd $(MMROOT) && \

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-terraform:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for terraform from resource list..."; \
 		cd $(MMROOT) && \
-		@sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
+		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e terraform -c azure -o $(TFROOT)/$(TFREPO)/; \
 	else \
 		echo "==> Generating source code for terraform from given name..."; \
 		cd $(MMROOT) && \
@@ -71,7 +71,7 @@ build-ansible:
 	@if [ -z "$(RESOURCE)" ]; then \
 		echo "==> Generating source code for ansible from resource list..."; \
 		cd $(MMROOT) && \
-		@sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
+		sh $(ROOT)/list_resources.sh | xargs -I '{}' bundle exec compiler -d -p $(SPECROOT)/'{}' -e ansible -c azure -o $(GENROOT)/$(ASREPO)/; \
 	else \
 		echo "==> Generating source code for ansible from given name..."; \
 		cd $(MMROOT) && \

--- a/list_resources.sh
+++ b/list_resources.sh
@@ -9,8 +9,8 @@ findResourceDir(){
 			if [ -n "$(git status -s $work_dir)" ] && [ -f $work_dir"/api.yaml" ] \
 				&& ([ -f $work_dir"/ansible.yaml" ] || [ -f $work_dir"/terraform.yaml" ]);
 			then
-				# remove the directory prefix
-				expr substr "$work_dir" `expr $prefix_len + $slash_len` "${#work_dir}"
+				# remove the directory prefix './specs'
+				expr substr "$work_dir" 9 "${#work_dir}"
 			fi
 			# find resource directory recursively
 			findResourceDir $work_dir
@@ -18,6 +18,6 @@ findResourceDir(){
 	done
 }
 
-prefix_len=${#1}
-slash_len=2
-findResourceDir $1
+cd `dirname $0`
+specs_dir='./specs'
+findResourceDir $specs_dir

--- a/list_resources.sh
+++ b/list_resources.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-specs_dir="./specs"
 
 findResourceDir(){
 	for file in `ls $1`
@@ -10,8 +9,8 @@ findResourceDir(){
 			if [ -n "$(git status -s $work_dir)" ] && [ -f $work_dir"/api.yaml" ] \
 				&& ([ -f $work_dir"/ansible.yaml" ] || [ -f $work_dir"/terraform.yaml" ]);
 			then
-				# remove the directory prefix './specs/'
-				expr substr "$work_dir" 9 "${#work_dir}"
+				# remove the directory prefix
+				expr substr "$work_dir" `expr $prefix_len + $slash_len` "${#work_dir}"
 			fi
 			# find resource directory recursively
 			findResourceDir $work_dir
@@ -19,4 +18,6 @@ findResourceDir(){
 	done
 }
 
-findResourceDir $specs_dir
+prefix_len=${#1}
+slash_len=2
+findResourceDir $1

--- a/list_resources.sh
+++ b/list_resources.sh
@@ -1,19 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 specs_dir="./specs"
 
-function findResourceDir(){
-    for file in `ls $1`
-    do
-    	work_dir=$1"/"$file
-        if [ -d $work_dir ]
-        then
-        	if [ -n "$(git status -s $work_dir)" ] && [ -f $work_dir"/api.yaml" ] \
-        		&& ([ -f $work_dir"/ansible.yaml" ] || [ -f $work_dir"/terraform.yaml" ]); then
-				echo ${work_dir:8}		# remove the directory prefix './specs/'
+findResourceDir(){
+	for file in `ls $1`
+	do
+		work_dir=$1"/"$file
+		if [ -d $work_dir ]
+		then
+			if [ -n "$(git status -s $work_dir)" ] && [ -f $work_dir"/api.yaml" ] \
+				&& ([ -f $work_dir"/ansible.yaml" ] || [ -f $work_dir"/terraform.yaml" ]);
+			then
+				# remove the directory prefix './specs/'
+				expr substr "$work_dir" 9 "${#work_dir}"
 			fi
-            findResourceDir $work_dir	# find resource directory recursively
-        fi
-    done
+			# find resource directory recursively
+			findResourceDir $work_dir
+		fi
+	done
 }
 
 findResourceDir $specs_dir

--- a/list_resources.sh
+++ b/list_resources.sh
@@ -17,7 +17,9 @@ findResourceDir(){
 		fi
 	done
 }
-
+# go to magic-module-specs directory
 cd `dirname $0`
 specs_dir='./specs'
 findResourceDir $specs_dir
+# back to magic-modules directory
+cd $1


### PR DESCRIPTION
This PR fixes the "bash command not found error" in #95. It replaces `bash` with `sh`, and adjusts the codes in list_resouces.sh to fit `sh`. 